### PR TITLE
Add OSX build support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,9 @@ example
 preprocessMatrices
 *.exe
 
+# OSX Executables and library output objects
+sha3/libshake.dylib
+create_test_vectors
+libpicnic.dylib
+libshake.dylib
+unit_test

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,33 @@
-
+ifeq ($(OS),Windows_NT)
+	UNAME_S=Windows
+else
+	UNAME_S := $(shell uname -s)
+endif
 CC=gcc
 WARNING_FLAGS=-Wall -Wextra -Wpedantic -Werror
 CFLAGS= -O2 -march=native $(WARNING_FLAGS) -std=gnu99 -D__LINUX__ -D__X64__ -I./sha3
 CFLAGS_DEBUG= -g -march=native $(WARNING_FLAGS) -std=gnu99 -fsanitize=address -D__LINUX__ -D__X64__ -I./sha3
-SHA3LIB=libshake.a
+ifeq ($(UNAME_S),Darwin)
+	SHA3LIB=libshake.dylib
+else
+	SHA3LIB=libshake.a
+endif
+
 SHA3_PATH=sha3
-LDFLAGS= $(SHA3_PATH)/$(SHA3LIB) 
+ifeq ($(UNAME_S),Darwin)
+	DYLIBFLAGS=-dynamiclib -undefined suppress -flat_namespace
+	LDFLAGS=$(SHA3LIB)
+else
+	LDFLAGS=$(SHA3_PATH)/$(SHA3LIB) 
+endif
 
 SOURCES= picnic_impl.c picnic.c lowmc_constants.c
 PICNIC_OBJECTS= picnic_impl.o picnic.o lowmc_constants.o hash.o picnic_types.o
-PICNIC_LIB= libpicnic.a
+ifeq ($(UNAME_S),Darwin)
+	PICNIC_LIB=libpicnic.dylib
+else
+	PICNIC_LIB=libpicnic.a
+endif
 EXECUTABLE_EXAMPLE=example
 EXECUTABLE_TESTVECTORS=create_test_vectors
 EXECUTABLE_UNITTEST=unit_test
@@ -41,7 +59,12 @@ $(EXECUTABLE_BENCHMARK): $(PICNIC_LIB)
 	    $(CC) -c $(CFLAGS) $< -o $@
 
 $(PICNIC_LIB): $(PICNIC_OBJECTS)
+ifeq ($(UNAME_S),Darwin)
+	mv $(SHA3_PATH)/$(SHA3LIB) .
+	$(CC) $^ -o $@ $(LDFLAGS) $(DYLIBFLAGS)
+else
 	ar rcs $@ $^
+endif
 
 
 clean:
@@ -52,5 +75,6 @@ clean:
 	    rm $(EXECUTABLE_UNITTEST) 2>/dev/null || true
 	    rm $(EXECUTABLE_TESTVECTORS) 2>/dev/null || true
 	    rm $(EXECUTABLE_BENCHMARK) 2>/dev/null || true
+			rm $(SHA3LIB) 2>/dev/null || true
 		rm $(PICNIC_LIB) 2>/dev/null || true
 		$(MAKE) -C $(SHA3_PATH) clean

--- a/README.md
+++ b/README.md
@@ -39,10 +39,22 @@ Open the solution in `VisualStudio\picnic.sln`, and build the projects.
 The project `libpicnic` creates a `.lib` file, containing the functions defined `in picnic.h`.  
 See the `example` project for a simple application that calls functions in 
 
+## OSX Build Instructions
+
+Tested on OSX High Sierra with clang 9.
+
+1. `make`  
+This will build the project. `make debug` will build with symbols and address sanitizer.
+
+2. `./example`  
+Runs an example program that exercises the keygen, sign, verify and
+serialization APIs.  See [example.c](https://github.com/Microsoft/Picnic/blob/master/example.c).
+
 ### Acknowledgments
 Thanks to Christian Paquin for providing feedback on picnic.h and for adding
-support for a Windows build
+support for a Windows build.
 
+Thanks to Robert Krzyzanowski for adding support for an OSX build.
 
 ### Contributing
 

--- a/osx/endian.h
+++ b/osx/endian.h
@@ -1,0 +1,35 @@
+// https://gist.github.com/yinyin/2027912
+#ifndef __FINK_ENDIANDEV_PKG_ENDIAN_H__
+#define __FINK_ENDIANDEV_PKG_ENDIAN_H__ 1
+
+/** compatibility header for endian.h
+ * This is a simple compatibility shim to convert
+ * BSD/Linux endian macros to the Mac OS X equivalents.
+ * It is public domain.
+ * */
+
+#ifndef __APPLE__
+	#warning "This header file (endian.h) is MacOS X specific.\n"
+#endif	/* __APPLE__ */
+
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+
+#endif	/* __FINK_ENDIANDEV_PKG_ENDIAN_H__ */
+

--- a/picnic_impl.c
+++ b/picnic_impl.c
@@ -21,7 +21,11 @@
 	#include <Windows.h>
 	#include <bcrypt.h>
 #else
+  #if defined(__APPLE__)
+    #include "osx/endian.h"
+  #else
     #include <endian.h>
+  #endif
 #endif
 
 #include "picnic_impl.h"

--- a/sha3/Makefile
+++ b/sha3/Makefile
@@ -1,20 +1,36 @@
+ifeq ($(OS),Windows_NT)
+	UNAME_S=Windows
+else
+	UNAME_S := $(shell uname -s)
+endif
 CC=gcc
 WARNING_FLAGS=-Wall -Wextra -Wpedantic -Werror -Wno-unused-function
 CFLAGS= -O2 -march=native $(WARNING_FLAGS) -std=gnu99 
 
 SOURCES=$(wildcard *.c)
 OBJECTS=$(patsubst %.c,%.o,$(wildcard *.c))
-SHA3LIB=libshake.a
+ifeq ($(UNAME_S),Darwin)
+	SHA3LIB=libshake.dylib
+else
+	SHA3LIB=libshake.a
+endif
 
+ifeq ($(UNAME_S),Darwin)
+	DYLIBFLAGS=-dynamiclib -undefined suppress -flat_namespace
+endif
 
 all: $(SOURCES) $(SHA3LIB)
 
 $(SHA3LIB): $(OBJECTS)
+ifeq ($(UNAME_S),Darwin)
+	$(CC) $^ -o $@ $(LDFLAGS) $(DYLIBFLAGS)
+else
 	ar rcs $@ $^
+endif
 
 #.c.o: 
 #	    $(CC) -c $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 clean:
 	rm *.o 2>/dev/null || true
-	rm libkeccak.a 2>/dev/null || true
+	rm $(SHA3LIB) 2>/dev/null || true


### PR DESCRIPTION
This pull request adds build support for OSX, tested on High Sierra with clang 9. See build log below.

Let me know what other modifications are required to get this merged. Thank you!

### Build log

```
> make
/Library/Developer/CommandLineTools/usr/bin/make -C sha3
gcc -O2 -march=native -Wall -Wextra -Wpedantic -Werror -Wno-unused-function -std=gnu99    -c -o KeccakHash.o KeccakHash.c
gcc -O2 -march=native -Wall -Wextra -Wpedantic -Werror -Wno-unused-function -std=gnu99    -c -o KeccakP-1600-reference.o KeccakP-1600-reference.c
gcc -O2 -march=native -Wall -Wextra -Wpedantic -Werror -Wno-unused-function -std=gnu99    -c -o KeccakSpongeWidth1600.o KeccakSpongeWidth1600.c
gcc KeccakHash.o KeccakP-1600-reference.o KeccakSpongeWidth1600.o -o libshake.dylib  -dynamiclib -undefined suppress -flat_namespace
gcc -c -O2 -march=native -Wall -Wextra -Wpedantic -Werror -std=gnu99 -D__LINUX__ -D__X64__ -I./sha3 picnic_impl.c -o picnic_impl.o
gcc -c -O2 -march=native -Wall -Wextra -Wpedantic -Werror -std=gnu99 -D__LINUX__ -D__X64__ -I./sha3 picnic.c -o picnic.o
gcc -c -O2 -march=native -Wall -Wextra -Wpedantic -Werror -std=gnu99 -D__LINUX__ -D__X64__ -I./sha3 lowmc_constants.c -o lowmc_constants.o
gcc -c -O2 -march=native -Wall -Wextra -Wpedantic -Werror -std=gnu99 -D__LINUX__ -D__X64__ -I./sha3 hash.c -o hash.o
gcc -c -O2 -march=native -Wall -Wextra -Wpedantic -Werror -std=gnu99 -D__LINUX__ -D__X64__ -I./sha3 picnic_types.c -o picnic_types.o
mv sha3/libshake.dylib .
gcc picnic_impl.o picnic.o lowmc_constants.o hash.o picnic_types.o -o libpicnic.dylib libshake.dylib -dynamiclib -undefined suppress -flat_namespace
gcc example.c -O2 -march=native -Wall -Wextra -Wpedantic -Werror -std=gnu99 -D__LINUX__ -D__X64__ -I./sha3 libpicnic.dylib -o example libshake.dylib
gcc create_test_vectors.c -O2 -march=native -Wall -Wextra -Wpedantic -Werror -std=gnu99 -D__LINUX__ -D__X64__ -I./sha3 libpicnic.dylib -o create_test_vectors libshake.dylib
gcc unit_test.c -O2 -march=native -Wall -Wextra -Wpedantic -Werror -std=gnu99 -D__LINUX__ -D__X64__ -I./sha3 libpicnic.dylib -o unit_test libshake.dylib
```

```
> ./example                                                                                                                                                                    
Picnic example with parameter set: Picnic_L1_FS
Generating key...  success
Max signature length 34000 bytes
Signing a 500 byte message...  success, signature is 32848 bytes
Verifying signature...  success
Testing public key serialization...  success
Testing private key serialization...  success
# Etc...
```
